### PR TITLE
Fix syntax in Git Hooks References section

### DIFF
--- a/text/31_Git_Hooks/0_ Git_Hooks.markdown
+++ b/text/31_Git_Hooks/0_ Git_Hooks.markdown
@@ -354,5 +354,5 @@ to abort.
 
 ### References ###
 
-[Git Hooks](http://www.kernel.org/pub/software/scm/git/docs/githooks.html)
+* [Git Hooks](http://www.kernel.org/pub/software/scm/git/docs/githooks.html)
 * http://probablycorey.wordpress.com/2008/03/07/git-hooks-make-me-giddy/


### PR DESCRIPTION
Just a little syntax glitch
