### PR TITLE
Interactive rebase modifications

### DIFF
--- a/text/14_Interactive_Rebasing/0_ Interactive_Rebasing.markdown
+++ b/text/14_Interactive_Rebasing/0_ Interactive_Rebasing.markdown
@@ -1,7 +1,7 @@
 ## Interactive Rebasing ##
 
 You can also rebase interactively.  This is often used to re-write your
-own commit objects before pusing them somewhere.  It is an easy way to 
+own commit objects before pushing them somewhere.  It is an easy way to 
 split, merge or re-order commits before sharing them with others.  You
 can also use it to clean up commits you've pulled from someone when
 applying them locally.

--- a/text/14_Interactive_Rebasing/0_ Interactive_Rebasing.markdown
+++ b/text/14_Interactive_Rebasing/0_ Interactive_Rebasing.markdown
@@ -55,6 +55,9 @@ and do the action specified.
 If 'pick' is specified, it will simply try to apply the patch and save the 
 commit with the same message as before.
 
+If 'reword' is specified, it will also try to apply the patch but will allow you
+to change the commit message before moving on.
+
 If 'squash' is specified, it will combine that commit with the previous one
 to create a new commit.  This will drop you into your editor again to merge
 the commit messages of the two commits it is now squashing together.  So, 

--- a/text/14_Interactive_Rebasing/0_ Interactive_Rebasing.markdown
+++ b/text/14_Interactive_Rebasing/0_ Interactive_Rebasing.markdown
@@ -58,6 +58,33 @@ commit with the same message as before.
 If 'reword' is specified, it will also try to apply the patch but will allow you
 to change the commit message before moving on.
 
+If 'edit' is specified, it will do the same thing, but then pause before 
+moving on to the next one and drop you into the command line so you can 
+amend the commit, or change the commit contents somehow.
+
+If you wanted to split a commit, for instance, you would specify 'edit' for
+that commit:
+
+	pick   fc62e55 added file_size
+	pick   9824bf4 fixed little thing
+	edit   21d80a5 added number to log
+	pick   76b9da6 added the apply command
+	pick   c264051 Revert "added file_size" - not implemented correctly
+
+And then when you get to the command line, you revert that commit and create
+two (or more) new ones.  Lets say 21d80a5 modified two files, file1 and file2,
+and you wanted to split them into seperate commits.  You could do this after
+the rebase dropped you to the command line :
+
+	$ git reset HEAD^
+	$ git add file1
+	$ git commit 'first part of split commit'
+	$ git add file2
+	$ git commit 'second part of split commit'
+	$ git rebase --continue
+	
+And now instead of 5 commits, you would have 6.
+
 If 'squash' is specified, it will combine that commit with the previous one
 to create a new commit.  This will drop you into your editor again to merge
 the commit messages of the two commits it is now squashing together.  So, 
@@ -95,33 +122,6 @@ Then you will have to create a single commit message from this:
 
 Once you have edited that down into once commit message and exit the editor,
 the commit will be saved with your new message.
-
-If 'edit' is specified, it will do the same thing, but then pause before 
-moving on to the next one and drop you into the command line so you can 
-amend the commit, or change the commit contents somehow.
-
-If you wanted to split a commit, for instance, you would specify 'edit' for
-that commit:
-
-	pick   fc62e55 added file_size
-	pick   9824bf4 fixed little thing
-	edit   21d80a5 added number to log
-	pick   76b9da6 added the apply command
-	pick   c264051 Revert "added file_size" - not implemented correctly
-
-And then when you get to the command line, you revert that commit and create
-two (or more) new ones.  Lets say 21d80a5 modified two files, file1 and file2,
-and you wanted to split them into seperate commits.  You could do this after
-the rebase dropped you to the command line :
-
-	$ git reset HEAD^
-	$ git add file1
-	$ git commit 'first part of split commit'
-	$ git add file2
-	$ git commit 'second part of split commit'
-	$ git rebase --continue
-	
-And now instead of 5 commits, you would have 6.
 
 The last useful thing that interactive rebase can do is drop commits for you.
 If instead of choosing 'pick', 'squash' or 'edit' for the commit line, you 

--- a/text/14_Interactive_Rebasing/0_ Interactive_Rebasing.markdown
+++ b/text/14_Interactive_Rebasing/0_ Interactive_Rebasing.markdown
@@ -58,8 +58,8 @@ commit with the same message as before.
 If 'reword' is specified, it will also try to apply the patch but will allow you
 to change the commit message before moving on.
 
-If 'edit' is specified, it will do the same thing, but then pause before 
-moving on to the next one and drop you into the command line so you can 
+If 'edit' is specified, it will do the same thing as 'pick', but then pause
+before moving on to the next one and drop you into the command line so you can
 amend the commit, or change the commit contents somehow.
 
 If you wanted to split a commit, for instance, you would specify 'edit' for

--- a/text/14_Interactive_Rebasing/0_ Interactive_Rebasing.markdown
+++ b/text/14_Interactive_Rebasing/0_ Interactive_Rebasing.markdown
@@ -32,8 +32,10 @@ of choice with something that looks like this:
 	#
 	# Commands:
 	#  p, pick = use commit
+	#  r, reword = use commit, but edit the commit message
 	#  e, edit = use commit, but stop for amending
 	#  s, squash = use commit, but meld into previous commit
+	#  f, fixup = like "squash", but discard this commit's log message
 	#
 	# If you remove a line here THAT COMMIT WILL BE LOST.
 	# However, if you remove everything, the rebase will be aborted.
@@ -44,11 +46,11 @@ one line per commit with the following format:
 
 	(action) (partial-sha) (short commit message)
 	
-Now, you can change the action (which is by default 'pick') to either 'edit'
-or 'squash', or just leave it as 'pick'.  You can also reorder the commits
-just by moving the lines around however you want.  Then, when you exit the 
-editor, git will try to apply the commits however they are now arranged and
-do the action specified. 
+Now, you can change the action (which is by default 'pick') to 'reword', 'edit',
+'squash', 'fixup', or 'exec', or just leave it as 'pick'.  You can also reorder
+the commits just by moving the lines around however you want. Then, when you
+exit the editor, git will try to apply the commits however they are now arranged
+and do the action specified. 
 
 If 'pick' is specified, it will simply try to apply the patch and save the 
 commit with the same message as before.

--- a/text/14_Interactive_Rebasing/0_ Interactive_Rebasing.markdown
+++ b/text/14_Interactive_Rebasing/0_ Interactive_Rebasing.markdown
@@ -123,6 +123,10 @@ Then you will have to create a single commit message from this:
 Once you have edited that down into once commit message and exit the editor,
 the commit will be saved with your new message.
 
+If 'fixup' is specified, the commit will be merged with the previous commit like
+with 'squash', but this commit's message will be discarded and you will not need
+to merge the commit messages. 
+
 The last useful thing that interactive rebase can do is drop commits for you.
 If instead of choosing 'pick', 'squash' or 'edit' for the commit line, you 
 simply remove the line, it will remove the commit from the history.


### PR DESCRIPTION
These commits are just some minor fixes for the interactive rebase [page](http://book.git-scm.com/4_interactive_rebasing.html).  The first is a typo fix while the remaining ones add simple paragraphs about the new interactive rebase options as of version 1.71.
