### PR TITLE
Fixed ASCII  diagram broken by errant indentation.

### DIFF
--- a/text/11_Distributed_Workflows_Clone_Fetch_Push/0_ Distributed_Workflows_Clone_Fetch_Push.markdown
+++ b/text/11_Distributed_Workflows_Clone_Fetch_Push/0_ Distributed_Workflows_Clone_Fetch_Push.markdown
@@ -147,7 +147,7 @@ like this:
     	| you pull                            | they pull
     	|                                     |
     	|                                     |
-            |               they push             V
+        |               they push             V
       their public repo <------------------- their repo
       
 


### PR DESCRIPTION
In section "Public git repositories", some extra indentation broke an ASCII
diagram.
