### PR TITLE
Fix missing -m option in Intractive Rebasing chapter

### DIFF
--- a/text/14_Interactive_Rebasing/0_ Interactive_Rebasing.markdown
+++ b/text/14_Interactive_Rebasing/0_ Interactive_Rebasing.markdown
@@ -111,9 +111,9 @@ the rebase dropped you to the command line :
 
 	$ git reset HEAD^
 	$ git add file1
-	$ git commit 'first part of split commit'
+	$ git commit -m 'first part of split commit'
 	$ git add file2
-	$ git commit 'second part of split commit'
+	$ git commit -m 'second part of split commit'
 	$ git rebase --continue
 	
 And now instead of 5 commits, you would have 6.


### PR DESCRIPTION
Correct me if I'm wrong but it seems to me that "git commit" command in the last part of the chapter(the one talking about splitting old commit in two) miss the "-m" option, right before what it seems to be a commit message. Fell free to discard this pull request in case I'm wrong.
