### PR TITLE
Missing code block in git-hooks chapter.

### DIFF
--- a/text/31_Git_Hooks/0_ Git_Hooks.markdown
+++ b/text/31_Git_Hooks/0_ Git_Hooks.markdown
@@ -199,7 +199,7 @@ This hook executes once for the receive operation. It takes no
 arguments, but for each ref to be updated it receives on standard
 input a line of the format:
 
-  <old-value> SP <new-value> SP <ref-name> LF
+    <old-value> SP <new-value> SP <ref-name> LF
 
 where `<old-value>` is the old object name stored in the ref,
 `<new-value>` is the new object name to be stored in the ref and


### PR DESCRIPTION
A line that was intended to be a code block was indented with 2 instead of 4 spaces.
which cause some of the text to disappear, because it looks like HTML tags.
