### PR TITLE
a tag isn't created using git tag "with no arguments"; phrase removed

### DIFF
--- a/text/12_Git_Tag/0_ Git_Tag.markdown
+++ b/text/12_Git_Tag/0_ Git_Tag.markdown
@@ -2,8 +2,7 @@
 
 ### Lightweight Tags ###
 
-We can create a tag to refer to a particular commit by running linkgit:git-tag[1]
-with no arguments.
+We can create a tag to refer to a particular commit by running linkgit:git-tag[1]:
 
     $ git tag stable-1 1b2e1d63ff
     


### PR DESCRIPTION
I hope this isn't a case of me being up too late and reading things wrong. When I issue "git tag" with no arguments, I get a list of tags in my repo. The following line -- the one that creates the tag -- has arguments.
